### PR TITLE
Add Tencent Kona JDKs

### DIFF
--- a/.github/workflows/update-tencent-kona.yml
+++ b/.github/workflows/update-tencent-kona.yml
@@ -1,0 +1,28 @@
+name: Update Tencent Kona
+
+on:
+  schedule:
+    - cron: 0 5 * * 1-5
+  workflow_dispatch:
+
+jobs:
+  run:
+    name: "Run Java Migration for Tencent Kona"
+    strategy:
+      fail-fast: false
+      matrix:
+        java-version: [ 8, 11, 17 ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Java 17
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'maven'
+      - name: Run tencent-kona
+        run: ./mvnw spring-boot:run -Dspring-boot.run.arguments="--foojay.java.distribution=kona --foojay.distribution.version=${{ matrix.java-version }} --foojay.java.release-status=ga"
+        env:
+          SDKMAN_RELEASE_CONSUMER_KEY: ${{ secrets.CONSUMER_KEY }}
+          SDKMAN_RELEASE_CONSUMER_TOKEN: ${{ secrets.CONSUMER_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -19,4 +19,5 @@ List of supported vendors:
 * OpenJDK
 * SapMachine
 * Eclipse Temurin
+* Tencent Kona
 * Trava OpenJDK

--- a/src/main/java/io/sdkman/automigration/adapters/PackageAdapter.java
+++ b/src/main/java/io/sdkman/automigration/adapters/PackageAdapter.java
@@ -25,7 +25,7 @@ public class PackageAdapter {
 			entry("graalvm_ce11", "grl"),
 			entry("graalvm_ce17", "grl"),
 			entry("graalvm_ce19", "grl"),
-            entry("kona", "tencent"),
+            entry("kona", "kona"),
             entry("liberica", "librca"),
             entry("microsoft", "ms"),
             entry("oracle", "oracle"),

--- a/src/main/java/io/sdkman/automigration/adapters/PackageAdapter.java
+++ b/src/main/java/io/sdkman/automigration/adapters/PackageAdapter.java
@@ -25,6 +25,7 @@ public class PackageAdapter {
 			entry("graalvm_ce11", "grl"),
 			entry("graalvm_ce17", "grl"),
 			entry("graalvm_ce19", "grl"),
+            entry("kona", "tencent"),
             entry("liberica", "librca"),
             entry("microsoft", "ms"),
             entry("oracle", "oracle"),

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -70,6 +70,18 @@ sdkman.gluon_graalvm.macos[1].archive-type=tar.gz
 sdkman.gluon_graalvm.windows[0].architecture=amd64
 sdkman.gluon_graalvm.windows[0].archive-type=zip
 
+#Kona
+sdkman.kona.linux[0].architecture=amd64
+sdkman.kona.linux[0].archive-type=tar.gz
+sdkman.kona.linux[1].architecture=arm64
+sdkman.kona.linux[1].archive-type=tar.gz
+sdkman.kona.macos[0].architecture=amd64
+sdkman.kona.macos[0].archive-type=tar.gz
+sdkman.kona.macos[1].architecture=arm64
+sdkman.kona.macos[1].archive-type=tar.gz
+sdkman.kona.windows[0].architecture=amd64
+sdkman.kona.windows[0].archive-type=zip
+
 #Liberica
 sdkman.liberica.linux[0].architecture=amd64
 sdkman.liberica.linux[0].archive-type=tar.gz


### PR DESCRIPTION
Tencent Kona JDK is a downstream of OpenJDK.
It has three releases: [8], [11] and [17].

[8]:
<https://github.com/Tencent/TencentKona-8>

[11]:
<https://github.com/Tencent/TencentKona-11>

[17]:
<https://github.com/Tencent/TencentKona-17>