### PR TITLE
Add Huawei BiSheng JDKs

### DIFF
--- a/.github/workflows/update-huawei-bisheng.yml
+++ b/.github/workflows/update-huawei-bisheng.yml
@@ -1,0 +1,28 @@
+name: Update Huawei BiSheng
+
+on:
+  schedule:
+    - cron: 0 15 * * 1-5
+  workflow_dispatch:
+
+jobs:
+  run:
+    name: "Run Java Migration for Huawei BiSheng"
+    strategy:
+      fail-fast: false
+      matrix:
+        java-version: [ 8, 17 ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Java 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'maven'
+      - name: Run huawei-bisheng
+        run: ./mvnw spring-boot:run -Dspring-boot.run.arguments="--foojay.java.distribution=bisheng --foojay.distribution.version=${{ matrix.java-version }} --foojay.java.release-status=ga"
+        env:
+          SDKMAN_RELEASE_CONSUMER_KEY: ${{ secrets.CONSUMER_KEY }}
+          SDKMAN_RELEASE_CONSUMER_TOKEN: ${{ secrets.CONSUMER_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ List of supported vendors:
 * IBM Semeru
 * Gluon GraalVM
 * GraalVM
+* Huawei BiSheng
 * Mandrel
 * Microsoft OpenJDK
 * Oracle

--- a/src/main/java/io/sdkman/automigration/adapters/PackageAdapter.java
+++ b/src/main/java/io/sdkman/automigration/adapters/PackageAdapter.java
@@ -20,6 +20,7 @@ public class PackageAdapter {
 			entry("mandrel", "mandrel"));
 
     private static final Map<String, String> FOOJAY_SDKMAN_JVM_VENDOR_MAPPING = Map.ofEntries(
+			entry("huawei", "bisheng"),
 			entry("corretto", "amzn"),
 			entry("dragonwell", "albba"),
 			entry("graalvm_community", "graalce"),

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -94,6 +94,12 @@ sdkman.gluon_graalvm.macos[1].archive-type=tar.gz
 sdkman.gluon_graalvm.windows[0].architecture=amd64
 sdkman.gluon_graalvm.windows[0].archive-type=zip
 
+#Huawei
+sdkman.huawei.linux[0].architecture=amd64
+sdkman.huawei.linux[0].archive-type=tar.gz
+sdkman.huawei.linux[1].architecture=arm64
+sdkman.huawei.linux[1].archive-type=tar.gz
+
 #JetBrains Runtime
 sdkman.jetbrains.linux[0].architecture=amd64
 sdkman.jetbrains.linux[0].archive-type=tar.gz


### PR DESCRIPTION
Huawei BiSheng JDK is a downstream of OpenJDK.
It has two releases: 8 and 17.