### PR TITLE
Add Mandrel MacOS Arm64 builds

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -157,6 +157,8 @@ sdkman.mandrel.linux[1].architecture=arm64
 sdkman.mandrel.linux[1].archive-type=tar.gz
 sdkman.mandrel.windows[0].architecture=amd64
 sdkman.mandrel.windows[0].archive-type=zip
+sdkman.mandrel.macos[0].architecture=arm64
+sdkman.mandrel.macos[0].archive-type=tar.gz
 
 #Microsoft
 sdkman.microsoft.linux[0].architecture=amd64


### PR DESCRIPTION
Mandrel starting with 23.1 will be releasing macos builds for apple silicon as well.