### PR TITLE
Update Mandrel 24.x release train to JDK 23

### DIFF
--- a/.github/workflows/update-mandrel.yml
+++ b/.github/workflows/update-mandrel.yml
@@ -17,7 +17,7 @@ jobs:
           - distribution-version: 23
             java-version: 21
           - distribution-version: 24
-            java-version: 22
+            java-version: 23
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
New Mandrel 24.1 release based on JDK 23 is out. Mandrel 24.0 based on JDK 22 is now deprecated.