### PR TITLE
Fix Mandrel and Liberica NIK Java 21

### DIFF
--- a/.github/workflows/update-bellsoft-liberica-nik-fx.yml
+++ b/.github/workflows/update-bellsoft-liberica-nik-fx.yml
@@ -15,9 +15,9 @@ jobs:
           - distribution-version: 23
             java-version: 17
           - distribution-version: 23
-            java-version: 24
+            java-version: 21
           - distribution-version: 24
-            java-version: 22
+            java-version: 24
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/update-bellsoft-liberica-nik.yml
+++ b/.github/workflows/update-bellsoft-liberica-nik.yml
@@ -15,9 +15,9 @@ jobs:
           - distribution-version: 23
             java-version: 17
           - distribution-version: 23
-            java-version: 24
+            java-version: 21
           - distribution-version: 24
-            java-version: 23
+            java-version: 24
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/update-mandrel.yml
+++ b/.github/workflows/update-mandrel.yml
@@ -15,7 +15,7 @@ jobs:
           - distribution-version: 23
             java-version: 17
           - distribution-version: 23
-            java-version: 24
+            java-version: 21
           - distribution-version: 24
             java-version: 24
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fix Mandrel and Liberica NIK for Java 21
Update Liberica NIK to use Java 24 instead of 23