### PR TITLE
Add GraalVM 26 EA

### DIFF
--- a/.github/workflows/update-graalvm-ea.yml
+++ b/.github/workflows/update-graalvm-ea.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java-version: [ 25 ]
+        java-version: [ 25, 26 ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
JDK 26 EA builds are also available from GraalVM: https://github.com/graalvm/oracle-graalvm-ea-builds/tags