### PR TITLE
Update Oracle JDK available versions

### DIFF
--- a/.github/workflows/update-oracle.yml
+++ b/.github/workflows/update-oracle.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java-version: [ 17, 21, 24 ]
+        java-version: [ 21, 25 ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Oracle originally released JDK 17 under the No-Fee Terms and Conditions (NFTC) license, which allowed anyone to use it freely for commercial and production purposes. However, this free access was only temporary. Oracle’s policy states that each Long-Term Support (LTS) release will receive free updates under the NFTC license until one year after the next LTS is released.

Since JDK 21 was released in September 2023, the free update period for JDK 17 ended in September 2024. After that date, new updates for JDK 17 are no longer available under the NFTC license. To continue receiving updates and patches for JDK 17, users need a paid Oracle Java SE subscription. Thus, we should drop the support for Oracle JDK 17.

Also, Oracle JDK 25 has been released on Sept. 16th, 2025.