### PR TITLE
Fix Mandrel and Liberica NIK 25

### DIFF
--- a/.github/workflows/update-bellsoft-liberica-nik-fx.yml
+++ b/.github/workflows/update-bellsoft-liberica-nik-fx.yml
@@ -16,7 +16,7 @@ jobs:
             java-version: 17
           - distribution-version: 23
             java-version: 21
-          - distribution-version: 24
+          - distribution-version: 25
             java-version: 25
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/update-bellsoft-liberica-nik.yml
+++ b/.github/workflows/update-bellsoft-liberica-nik.yml
@@ -16,7 +16,7 @@ jobs:
             java-version: 17
           - distribution-version: 23
             java-version: 21
-          - distribution-version: 24
+          - distribution-version: 25
             java-version: 25
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/update-mandrel.yml
+++ b/.github/workflows/update-mandrel.yml
@@ -16,7 +16,7 @@ jobs:
             java-version: 17
           - distribution-version: 23
             java-version: 21
-          - distribution-version: 24
+          - distribution-version: 25
             java-version: 25
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Fixes Mandrel and Liberica NIK for Java 25, as we needed to update distribution as well.
Mandrel 25 was released today, and Disco API only runs update for it once a day... so after it runs the update there, SDKMan will make Mandrel 25 available to use =)  